### PR TITLE
Themes: Reference app resource when compiling theme [1/2]

### DIFF
--- a/cmds/installd/installd.cpp
+++ b/cmds/installd/installd.cpp
@@ -163,12 +163,12 @@ static int do_idmap(char **arg, char reply[REPLY_MAX] __unused)
 
 static int do_aapt(char **arg, char reply[REPLY_MAX] __unused)
 {
-    return aapt(arg[0], arg[1], arg[2], atoi(arg[3]), atoi(arg[4]), atoi(arg[5]), "");
+    return aapt(arg[0], arg[1], arg[2], atoi(arg[3]), atoi(arg[4]), atoi(arg[5]), arg[6], "");
 }
 
 static int do_aapt_with_common(char **arg, char reply[REPLY_MAX] __unused)
 {
-    return aapt(arg[0], arg[1], arg[2], atoi(arg[3]), atoi(arg[4]), atoi(arg[5]), arg[6]);
+    return aapt(arg[0], arg[1], arg[2], atoi(arg[3]), atoi(arg[4]), atoi(arg[5]), arg[6], arg[7]);
 }
 
 static int do_restorecon_data(char **arg, char reply[REPLY_MAX] __attribute__((unused)))
@@ -223,8 +223,8 @@ struct cmdinfo cmds[] = {
     { "mkuserconfig",         1, do_mk_user_config },
     { "rmuser",               2, do_rm_user },
     { "idmap",                6, do_idmap },
-    { "aapt",                 6, do_aapt },
-    { "aapt_with_common",     7, do_aapt_with_common },
+    { "aapt",                 7, do_aapt },
+    { "aapt_with_common",     8, do_aapt_with_common },
     { "restorecondata",       4, do_restorecon_data },
     { "createoatdir",         2, do_create_oat_dir },
     { "rmpackagedir",         1, do_rm_package_dir },

--- a/cmds/installd/installd.h
+++ b/cmds/installd/installd.h
@@ -253,7 +253,7 @@ int linklib(const char* uuid, const char* pkgname, const char* asecLibDir, int u
 int idmap(const char *target_path, const char *overlay_path, const char *cache_path, uid_t uid,
           uint32_t target_hash, uint32_t overlay_hash);
 int aapt(const char *source_apk, const char *internal_path, const char *out_restable, uid_t uid,
-         int pkgId, int min_sdk_version, const char *common_res_path);
+         int pkgId, int min_sdk_version, const char *app_res_path, const char *common_res_path);
 int restorecon_data(const char *uuid, const char* pkgName, const char* seinfo, uid_t uid);
 int create_oat_dir(const char* oat_dir, const char *instruction_set);
 int rm_package_dir(const char* apk_path);


### PR DESCRIPTION
This allows us to pass in the path to the target apk as an additional
included resource apk, allowing theme designers to reference styles
and attributes from the original package without needing to duplicate
them.  Duplicating attributes never worked quite well, and causes
all sorts of issues, including crashing apps.

Instead of a theme declaring attributes, that are app specific, it
simply reference the originals.  This way things like colors that
are style specific get included correctly.

Here's an example of stat_sys_wifi_signal_4_fully.xml using this feature.
By using ?com.android.systemui:attr/ we are able to reference attributes
defined in SystemUI directly in our themed resource.

<vector xmlns:android="http://schemas.android.com/apk/res/android"
    android:width="17.25dp"
    android:height="18dp"
    android:viewportWidth="46.0"
    android:viewportHeight="48.0">

```
<path
    android:fillColor="?com.android.systemui:attr/backgroundColor"
    android:pathData="M20.4,18.0"/>
<path
    android:fillColor="?com.android.systemui:attr/fillColor"
    android:pathData="M42.0,32.0l0.0,-4.0L26.0,18.0L26.0,7.0c0.0,-1.7 -1.3,-3.0 -3.0,
    -3.0c-1.7,0.0 -3.0,1.3 -3.0,3.0l0.0,11.0L4.0,28.0l0.0,4.0l16.0,-5.0l0.0,11.0l-4.0,
    3.0l0.0,3.0l7.0,-2.0l7.0,2.0l0.0,-3.0l-4.0,-3.0L26.0,27.0L42.0,32.0z"/>
```

</vector>

Change-Id: Ic00b5d91fc651a29a8c3ab341e5494107acd0463
TICKET: CYNGNOS-1645
