### PR TITLE
surfaceflinger: Don't allow QC HWC virtual display without QC HWC copy

### DIFF
--- a/services/surfaceflinger/DisplayUtils.cpp
+++ b/services/surfaceflinger/DisplayUtils.cpp
@@ -175,8 +175,14 @@ bool DisplayUtils::canAllocateHwcDisplayIdForVDS(int usage) {
     int flag_mask = 0xffffffff;
 
 #ifdef QTI_BSP
+#ifdef FORCE_HWC_COPY_FOR_VIRTUAL_DISPLAYS
     // Reserve hardware acceleration for WFD use-case
     flag_mask = GRALLOC_USAGE_PRIVATE_WFD;
+#else
+    // Don't allocate HWC display unless we force HWC copy, otherwise
+    // incompatible buffers are sent to the media stack
+    flag_mask = 0;
+#endif
 #endif
 
     return (usage & flag_mask);


### PR DESCRIPTION
- QC media encoder appears to be incapable of switching between RGBA8888
  buffers and NV12_ENCODEABLE dynamically. This requires that we switch
  the entire stack to use the QC opaque format, or RGBA8888.

REF: CRACKLING-938
Change-Id: Ibd6a8faf8d268d3bfb4d61e4118a778ed82f1ab5
